### PR TITLE
Delete contenedor_seguimiento_egresados/seguimiento_egresados/run.sh

### DIFF
--- a/contenedor_seguimiento_egresados/seguimiento_egresados/run.sh
+++ b/contenedor_seguimiento_egresados/seguimiento_egresados/run.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-sleep 15
-python3 -u manage.py makemigrations
-python3 -u manage.py migrate
-gunicorn --bind :8000 seguimiento_egresados.wsgi:application --reload


### PR DESCRIPTION
Eliminando el archivo para poder cargar uno nuevo con el formato de fin de linea de linux.